### PR TITLE
fix: prevent top frame navigation when loading homepage

### DIFF
--- a/newtab.js
+++ b/newtab.js
@@ -10,8 +10,9 @@
   // When we navigate away from the homepage, navigate the top level instead
   const currTab = await browser.tabs.getCurrent()
   browser.webNavigation.onBeforeNavigate.addListener(e => {
+    const isNotHomepage = e.url.indexOf(homepageRaw) === -1;
     console.log(e)
-    if (e.tabId === currTab.id && e.frameId !== 0 && e.parentFrameId === 0) {
+    if (e.tabId === currTab.id && e.frameId !== 0 && e.parentFrameId === 0 && isNotHomepage) {
       window.location.href = e.url
     }
   })


### PR DESCRIPTION
Currently just opening a new tab can result in the home page being loaded into the top frame, which has the negative side effect that the address bar is now filled with the home page's URL. The issue is that the `onBeforeNavigate` listener can already be triggered by setting the initial home page URL on the new tab iframe here:
https://github.com/daisylb/newtab/blob/5529c799e0fccc381759258a5aa13856eb0bdef0/newtab.js#L8

This change fixes the issue by preventing the listener from changing the top frame location if the URL being navigated to is the home page.

Fixes #4 